### PR TITLE
⬆ require symfony 6

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -9,8 +9,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - { php-version: '8.0', dependencies: lowest }
-          - { php-version: '8.1', dependencies: highest }
+          - { php-version: '8.1', dependencies: lowest }
+          - { php-version: '8.2', dependencies: highest }
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 $finder = PhpCsFixer\Finder::create()
     ->in([
         __DIR__ . '/src',
@@ -8,27 +10,46 @@ $finder = PhpCsFixer\Finder::create()
 
 return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
-    ->setRules([
-        '@PSR12'          => true,
-        '@PhpCsFixer'     => true,
-        '@PHP81Migration' => true,
-
-        'binary_operator_spaces' => [
-            'operators' => [
-                '=>' => 'align_single_space_minimal',
-                '='  => 'align_single_space_minimal',
-            ],
-        ],
-        'class_definition'            => ['multi_line_extends_each_single_line' => true],
-        'concat_space'                => ['spacing' => 'one'],
-        'modernize_strpos'            => true,
-        'phpdoc_align'                => ['align' => 'left'],
-        'phpdoc_no_empty_return'      => false,
-        'phpdoc_to_comment'           => false,
-        'phpdoc_types_order'          => ['null_adjustment' => 'always_last', 'sort_algorithm' => 'none'],
-        'standardize_increment'       => false,
-        'trailing_comma_in_multiline' => ['elements' => ['arrays', 'arguments', 'parameters']],
-        'yoda_style'                  => false,
-    ])
     ->setFinder($finder)
+    ->setRules([
+        '@PSR12'                                           => true,
+        '@PhpCsFixer'                                      => true,
+        '@PhpCsFixer:risky'                                => true,
+        '@PHP80Migration:risky'                            => true,
+        '@PHP81Migration'                                  => true,
+        'binary_operator_spaces'                           => ['operators' => \array_fill_keys(['=', '=>', '??=', '.=', '+=', '-=', '*=', '/=', '%=', '**=', '&=', '|=', '^=', '<<=', '>>='], 'align_single_space_minimal')],
+        'blank_line_before_statement'                      => ['statements' => ['break', 'case', 'continue', 'declare', 'default', 'do', 'exit', 'for', 'foreach', 'goto', 'if', 'include', 'include_once', 'phpdoc', 'require', 'require_once', 'return', 'switch', 'throw', 'try', 'while', 'yield', 'yield_from']],
+        'class_definition'                                 => ['multi_line_extends_each_single_line' => true, 'single_item_single_line' => true],
+        'concat_space'                                     => ['spacing' => 'one'],
+        'date_time_create_from_format_call'                => true,
+        'date_time_immutable'                              => true,
+        'declare_strict_types'                             => true,
+        'final_class'                                      => true,
+        'get_class_to_class_keyword'                       => true,
+        'global_namespace_import'                          => ['import_classes' => true, 'import_constants' => true, 'import_functions' => true],
+        'increment_style'                                  => ['style' => 'post'],
+        'mb_str_functions'                                 => true,
+        'modernize_strpos'                                 => true,
+        'native_constant_invocation'                       => true,
+        'native_function_invocation'                       => ['include' => ['@all']],
+        'nullable_type_declaration_for_default_null_value' => true,
+        'ordered_imports'                                  => ['imports_order' => ['class', 'const', 'function'], 'sort_algorithm' => 'alpha'],
+        'ordered_interfaces'                               => ['direction' => 'ascend', 'order' => 'alpha'],
+        'phpdoc_align'                                     => ['align' => 'left'],
+        'phpdoc_line_span'                                 => true,
+        'phpdoc_order_by_value'                            => ['annotations' => ['author', 'covers', 'coversNothing', 'dataProvider', 'depends', 'group', 'internal', 'method', 'mixin', 'property', 'property-read', 'property-write', 'requires', 'throws', 'uses']],
+        'phpdoc_separation'                                => ['groups' => [['deprecated', 'link', 'see', 'since'], ['author', 'copyright', 'license'], ['category', 'package', 'subpackage'], ['property', 'phpstan-property', 'property-read', 'phpstan-property-read', 'property-write', 'phpstan-property-write'], ['param', 'phpstan-param'], ['return', 'phpstan-return']]],
+        'phpdoc_to_comment'                                => false,
+        'phpdoc_types_order'                               => ['null_adjustment' => 'always_last', 'sort_algorithm' => 'none'],
+        'regular_callable_call'                            => true,
+        'self_static_accessor'                             => true,
+        'simplified_if_return'                             => true,
+        'single_quote'                                     => ['strings_containing_single_quote_chars' => true],
+        'standardize_increment'                            => false,
+        'static_lambda'                                    => true,
+        'strict_comparison'                                => true,
+        'strict_param'                                     => true,
+        'trailing_comma_in_multiline'                      => ['elements' => ['arrays', 'arguments', 'match', 'parameters']],
+        'yoda_style'                                       => ['equal' => false, 'identical' => false, 'less_and_greater' => false],
+    ])
 ;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.0.0
+
+- Allow for symfony/validator:^6.0
+- Update PHPStan
+- Update PHP-CS-Fixer
+- Make classes final
+- Add native parameter types to `validate`, `validateProperty`, `validatePropertyValue`, `getMetadataFor` and `hasMetadataFor` methods of Validator class
+
 ## 1.0.0
 
 First Release

--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,9 @@
   ],
   "require": {
     "php": "^8.1",
-    "symfony/framework-bundle": "^5.4|^6.0",
+    "symfony/framework-bundle": "^6.0",
     "symfony/service-contracts": "^2.2|^3.0",
-    "symfony/validator": "^5.4|^6.0"
+    "symfony/validator": "^6.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.13",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "gal-digital-gmbh/validation",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "type": "symfony-bundle",
   "description": "Make validation simple",
   "keywords": [
@@ -27,11 +27,11 @@
     "php": "^8.0",
     "symfony/framework-bundle": "^5.4|^6.0",
     "symfony/service-contracts": "^2.2|^3.0",
-    "symfony/validator": "^5.4"
+    "symfony/validator": "^5.4|^6.0"
   },
   "require-dev": {
-    "friendsofphp/php-cs-fixer": "^3.8",
-    "phpstan/phpstan": "^1.4"
+    "friendsofphp/php-cs-fixer": "^3.13",
+    "phpstan/phpstan": "^1.10"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     }
   ],
   "require": {
-    "php": "^8.0",
+    "php": "^8.1",
     "symfony/framework-bundle": "^5.4|^6.0",
     "symfony/service-contracts": "^2.2|^3.0",
     "symfony/validator": "^5.4|^6.0"

--- a/src/DependencyInjection/ValidationExtension.php
+++ b/src/DependencyInjection/ValidationExtension.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GalDigitalGmbh\Validation\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
@@ -7,14 +9,12 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
-class ValidationExtension extends Extension
+final class ValidationExtension extends Extension
 {
     /**
      * @param mixed[] $configs
-     *
-     * @return void
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yaml');

--- a/src/Symfony/EventSubscriber/ValidationExceptionSubscriber.php
+++ b/src/Symfony/EventSubscriber/ValidationExceptionSubscriber.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GalDigitalGmbh\Validation\Symfony\EventSubscriber;
 
 use GalDigitalGmbh\Validation\Symfony\Exception\ValidationException;
@@ -9,7 +11,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
-class ValidationExceptionSubscriber implements EventSubscriberInterface
+final class ValidationExceptionSubscriber implements EventSubscriberInterface
 {
     public static function getSubscribedEvents(): array
     {

--- a/src/Symfony/Exception/ValidationException.php
+++ b/src/Symfony/Exception/ValidationException.php
@@ -10,9 +10,6 @@ use Symfony\Component\Validator\ConstraintViolationListInterface;
 
 final class ValidationException extends RuntimeException
 {
-    /**
-     * @param ConstraintViolationListInterface<mixed> $violations
-     */
     public function __construct(
         private ConstraintViolationListInterface $violations,
     ) {

--- a/src/Symfony/Exception/ValidationException.php
+++ b/src/Symfony/Exception/ValidationException.php
@@ -1,11 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GalDigitalGmbh\Validation\Symfony\Exception;
 
 use RuntimeException;
+use Stringable;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 
-class ValidationException extends RuntimeException
+final class ValidationException extends RuntimeException
 {
     /**
      * @param ConstraintViolationListInterface<mixed> $violations
@@ -29,7 +32,11 @@ class ValidationException extends RuntimeException
         $messages = [];
 
         foreach ($this->getViolations() as $violation) {
-            $messages[$violation->getPropertyPath()][] = $violation->getMessage();
+            $message = $violation->getMessage();
+
+            $messages[$violation->getPropertyPath()][] = $message instanceof Stringable
+                ? $message->__toString()
+                : $message;
         }
 
         return $messages;

--- a/src/Symfony/Traits/HasValidator.php
+++ b/src/Symfony/Traits/HasValidator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GalDigitalGmbh\Validation\Symfony\Traits;
 
 use GalDigitalGmbh\Validation\Symfony\Validator;

--- a/src/Symfony/Validator.php
+++ b/src/Symfony/Validator.php
@@ -1,12 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GalDigitalGmbh\Validation\Symfony;
 
 use GalDigitalGmbh\Validation\Symfony\Exception\ValidationException;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\Collection;
+use Symfony\Component\Validator\Constraints\GroupSequence;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 use Symfony\Component\Validator\Mapping\MetadataInterface;
@@ -14,7 +18,11 @@ use Symfony\Component\Validator\Validator\ContextualValidatorInterface;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Contracts\Service\Attribute\Required;
 
-class Validator implements ValidatorInterface
+use function array_keys;
+use function array_merge;
+use function count;
+
+final class Validator implements ValidatorInterface
 {
     private RequestStack $requestStack;
 
@@ -35,10 +43,14 @@ class Validator implements ValidatorInterface
         return $this->filterValidatedData($constraints, $value);
     }
 
+    /**
+     * @param Constraint|Constraint[] $constraints
+     * @param string|GroupSequence|array<string|GroupSequence>|null $groups
+     */
     public function validate(
-        $value,
-        $constraints = null,
-        $groups = null,
+        mixed $value,
+        Constraint|array $constraints = null,
+        string|GroupSequence|array $groups = null,
         bool $throwException = true,
     ): ConstraintViolationListInterface {
         $violations = $this->validator->validate($value, $constraints, $groups);
@@ -46,10 +58,13 @@ class Validator implements ValidatorInterface
         return $this->throwViolationsIfNecessary($violations, $throwException);
     }
 
+    /**
+     * @param string|GroupSequence|array<string|GroupSequence>|null $groups
+     */
     public function validateProperty(
         object $object,
         string $propertyName,
-        $groups = null,
+        string|GroupSequence|array $groups = null,
         bool $throwException = true,
     ): ConstraintViolationListInterface {
         $violations = $this->validator->validateProperty($object, $propertyName, $groups);
@@ -57,11 +72,14 @@ class Validator implements ValidatorInterface
         return $this->throwViolationsIfNecessary($violations, $throwException);
     }
 
+    /**
+     * @param string|GroupSequence|array<string|GroupSequence>|null $groups
+     */
     public function validatePropertyValue(
-        $objectOrClass,
+        object|string $objectOrClass,
         string $propertyName,
-        $value,
-        $groups = null,
+        mixed $value,
+        string|GroupSequence|array $groups = null,
         bool $throwException = true,
     ): ConstraintViolationListInterface {
         $violations = $this->validator->validatePropertyValue($objectOrClass, $propertyName, $value, $groups);
@@ -79,12 +97,12 @@ class Validator implements ValidatorInterface
         return $this->validator->inContext($context);
     }
 
-    public function getMetadataFor($value): MetadataInterface
+    public function getMetadataFor(mixed $value): MetadataInterface
     {
         return $this->validator->getMetadataFor($value);
     }
 
-    public function hasMetadataFor($value): bool
+    public function hasMetadataFor(mixed $value): bool
     {
         return $this->validator->hasMetadataFor($value);
     }

--- a/src/ValidationBundle.php
+++ b/src/ValidationBundle.php
@@ -1,10 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace GalDigitalGmbh\Validation;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class ValidationBundle extends Bundle
+final class ValidationBundle extends Bundle
 {
-
 }


### PR DESCRIPTION
- Require Symfony 6
- Update minimum required php version to 8.1
- Update PHPStan
- Update PHP-CS-Fixer
- Make classes final
- Add native parameter types to 'validate', 'validateProperty', 'validatePropertyValue', 'getMetadataFor' and 'hasMetadataFor' methods of Validator class